### PR TITLE
Added sh files to run common demo commands

### DIFF
--- a/rosemary/blog/Dockerfile
+++ b/rosemary/blog/Dockerfile
@@ -12,7 +12,7 @@ COPY pconf /spire/plugin/agent/.conf
 COPY artifact.tgz /
 COPY ghostunnel /root/
 COPY sidecar_config.hcl /sidecar/
-COPY nc.sh /spire/
+COPY *.sh /spire/
 RUN tar --directory / -xvzf /artifact.tgz
 WORKDIR /spire/
 

--- a/rosemary/blog/base_svid.sh
+++ b/rosemary/blog/base_svid.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+openssl x509 -inform der -in /spire/base_svid.crt -noout -text

--- a/rosemary/blog/sidecar_svid.sh
+++ b/rosemary/blog/sidecar_svid.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+openssl x509 -in /sidecar/0.key -noout -text

--- a/rosemary/blog/sidecar_uid.sh
+++ b/rosemary/blog/sidecar_uid.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+ps -no uid,comm | grep sidecar

--- a/rosemary/database/Dockerfile
+++ b/rosemary/database/Dockerfile
@@ -12,7 +12,7 @@ COPY pconf /spire/plugin/agent/.conf
 COPY artifact.tgz /
 COPY ghostunnel /root/
 COPY sidecar_config.hcl /sidecar/
-COPY nc.sh /spire/
+COPY *.sh /spire/
 RUN tar --directory / -xvzf /artifact.tgz
 WORKDIR /spire/
 

--- a/rosemary/database/base_svid.sh
+++ b/rosemary/database/base_svid.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+openssl x509 -inform der -in /spire/base_svid.crt -noout -text

--- a/rosemary/database/sidecar_svid.sh
+++ b/rosemary/database/sidecar_svid.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+openssl x509 -in /sidecar/0.key -noout -text

--- a/rosemary/database/sidecar_uid.sh
+++ b/rosemary/database/sidecar_uid.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+ps -no uid,comm | grep sidecar


### PR DESCRIPTION
Added sh files to run common demo commands. These commands are:

`./base_svid.sh` Inspect Base SVID
`./sidecar_uid.sh` Check Sidecar UID
`./sidecar_svid.sh` Inspect Sidecar SVID

And can be run in any of the agent containers.