### PR TITLE
Set /opt/spire as the default dir

### DIFF
--- a/beatrice/provision_db.sh
+++ b/beatrice/provision_db.sh
@@ -26,3 +26,6 @@ cat /extra_mount/blog/forum_db.dump | sudo mysql forum_db
 
 # install sidecar
 /extra_mount/install_sidecar.sh
+
+# drop user into /opt/spire dir
+echo "cd /opt/spire" >> /home/ubuntu/.bashrc

--- a/beatrice/provision_k8s-master.sh
+++ b/beatrice/provision_k8s-master.sh
@@ -18,3 +18,6 @@ kubectl create -f /extra_mount/blog/blog.yaml
 
 # install and start spire-server
 /extra_mount/install_spire.sh server
+
+# drop user into /opt/spire dir
+echo "cd /opt/spire" >> /home/ubuntu/.bashrc

--- a/beatrice/provision_k8s-node.sh
+++ b/beatrice/provision_k8s-node.sh
@@ -5,3 +5,5 @@ set -x
 # install and start spire-agent
 /extra_mount/install_spire.sh agent
 
+# drop user into /opt/spire dir
+echo "cd /opt/spire" >> /home/ubuntu/.bashrc


### PR DESCRIPTION
We end up having to cd into /opt/spire on nearly every terminal, so cd into it by default

@amartinezfayo @drrt 