### PR TITLE
Install grok exporter

### DIFF
--- a/drew/Makefile
+++ b/drew/Makefile
@@ -1,7 +1,7 @@
 
 
 init:
-	./drew.sh.sh init
+	./drew.sh init
 
 ami:
 	./drew.sh packer

--- a/drew/aws.tf
+++ b/drew/aws.tf
@@ -89,6 +89,15 @@ resource "aws_security_group_rule" "self" {
   security_group_id = "${aws_security_group.default.id}"
 }
 
+resource "aws_security_group_rule" "grok_exporter" {
+  type              = "ingress"
+  from_port         = 8089
+  to_port           = 8089
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = "${aws_security_group.default.id}"
+}
+
 resource "aws_security_group_rule" "https" {
   type              = "ingress"
   from_port         = 80

--- a/drew/drew.sh
+++ b/drew/drew.sh
@@ -3,7 +3,7 @@
 declare -rx TF_VAR_SPIRE_TGZ="${SPIRE_TGZ:-https://s3.us-east-2.amazonaws.com/scytale-artifacts/spire/spire-c37711f-linux-x86_64-glibc.tar.gz}"
 declare -rx TF_VAR_AWS_IID_TGZ="${AWS_IID_TGZ:-https://github.com/spiffe/aws-iid-attestor/releases/download/0.1/nodeattestor-aws_iid_0.1_linux_x86_64.tar.gz}"
 declare -rx TF_VAR_AWS_RES_TGZ="${AWS_RES_TGZ:-https://github.com/spiffe/aws-resolver/releases/download/0.1.1/noderesolver-aws_0.1.1_linux_x86_64.tar.gz}"
-
+declare -rx TF_VAR_GROK_EXPORTR_TGZ="${GROK_EXPORTR_TGZ:-https://github.com/fstab/grok_exporter/releases/download/v0.2.4/grok_exporter-0.2.4.linux-amd64.zip}"
 declare -rx TF_VAR_REGION="us-east-2"
 declare -rx TF_VAR_AZ="a"
 # note that you will have to change the server address elsewhere if you update the VPC CIDR

--- a/drew/packer.json
+++ b/drew/packer.json
@@ -5,6 +5,7 @@
     "SPIRE_TGZ": "{{env `TF_VAR_SPIRE_TGZ`}}",
     "AWS_IID_TGZ": "{{env `TF_VAR_AWS_IID_TGZ`}}",
     "AWS_RES_TGZ": "{{env `TF_VAR_AWS_RES_TGZ`}}",
+    "GROK_EXPORTR_TGZ": "{{env `TF_VAR_GROK_EXPORTR_TGZ`}}",
     "demo_name": "{{env `demo_name`}}"
   },
   "builders": [
@@ -91,6 +92,7 @@
       "NUM_WORKLOAD={{user `WORKLOADS`}}",
       "SPIRE_TGZ={{user `SPIRE_TGZ`}}",
       "AWS_IID_TGZ={{user `AWS_IID_TGZ`}}",
+      "GROK_EXPORTR_TGZ={{user `GROK_EXPORTR_TGZ`}}",
       "AWS_RES_TGZ={{user `AWS_RES_TGZ`}}"
 	]
 	}

--- a/drew/remote/grok-exporter.service
+++ b/drew/remote/grok-exporter.service
@@ -1,0 +1,10 @@
+[Service]
+Type=simple
+User=ubuntu
+Restart=always
+RestartSec=3
+WorkingDirectory=/opt/grok_exporter
+ExecStart=/opt/grok_exporter --config /opt/grok_exporter/grok_exporter.yml run
+
+[Install]
+WantedBy=multi-user.target

--- a/drew/remote/grok_config.yml
+++ b/drew/remote/grok_config.yml
@@ -22,4 +22,4 @@ metrics:
 
 server:
     host: 0.0.0.0
-    port: 8081
+    port: 8089

--- a/drew/remote/grok_config.yml
+++ b/drew/remote/grok_config.yml
@@ -1,0 +1,25 @@
+global:
+    config_version: 2
+input:
+    type: file
+    path: /var/log/syslog
+    readall: true # Read from the beginning of the file? False means we start at the end of the file and read only new lines.
+grok:
+    patterns_dir: /opt/grok_exporter/patterns
+metrics:
+    - type: counter
+      name: csr_request
+      help: number of CSR requests
+      match: '%{SPIRE_SERVER_CSR_REQUEST:csr}'
+      labels:
+          csr: '{{.csr}}'
+    - type: counter
+      name: node_attestation_request
+      help: number of node_attestaion requests
+      match: '%{SPIRE_SERVER_NODE_ATTESTATION:node_attestation}'
+      labels:
+          node_attestation: '{{.node_attestation}}'
+
+server:
+    host: 0.0.0.0
+    port: 8081

--- a/drew/remote/install_spire.sh
+++ b/drew/remote/install_spire.sh
@@ -9,12 +9,22 @@ NUM_WORKLOAD=${NUM_WORKLOAD:-10}
 #SPIRE_TGZ
 #AWS_IID_TGZ
 #AWS_RES_TGZ
-
+#GROK_EXPORTR_TGZ
 mode="$1"
 sudo rm -rf /opt/spire*
 curl --silent --location $SPIRE_TGZ | sudo tar --directory /opt -xzf -
 curl --silent --location $AWS_IID_TGZ | sudo tar --directory /opt/spire* -xzf -
 curl --silent --location $AWS_RES_TGZ | sudo tar --directory /opt/spire* -xzf -
+
+if [[ $mode == "server" ]]; then
+    sudo rm -rf /opt/grok_exporter*
+    curl --silent --location $GROK_EXPORTR_TGZ | sudo tar --directory /opt -xzf -
+    sudo cp /tmp/remote/grok_config.yml /opt/grok_config.yml
+    sudo cp /tmp/remote/spire /opt/grok_exporter/patterns/spire
+    sudo chown -R ubuntu:ubuntu /opt/grok_exporter*
+    sudo cp /tmp/remote/systemd/grok-exporter.service /etc/systemd/system/
+    sudo systemctl enable grok-exporter.service
+fi
 
 cd /opt
 ls opt/spire-* >/dev/null 2>&1 && sudo ln -s spire-* spire

--- a/drew/remote/install_spire.sh
+++ b/drew/remote/install_spire.sh
@@ -18,10 +18,12 @@ curl --silent --location $AWS_RES_TGZ | sudo tar --directory /opt/spire* -xzf -
 
 if [[ $mode == "server" ]]; then
     sudo rm -rf /opt/grok_exporter*
-    curl --silent --location $GROK_EXPORTR_TGZ | sudo tar --directory /opt -xzf -
-    sudo cp /tmp/remote/grok_config.yml /opt/grok_config.yml
-    sudo cp /tmp/remote/spire /opt/grok_exporter/patterns/spire
+    sudo apt install unzip
+    curl --silent --location $GROK_EXPORTR_TGZ -o grok_exporter.zip;sudo unzip grok_exporter.zip -d /opt; rm grok_exporter.zip; 
+    sudo ln -s /opt/grok_exporter* /opt/grok_exporter
+    sudo cp /tmp/remote/grok_config.yml /opt/grok_exporter/grok_config.yml
     sudo chown -R ubuntu:ubuntu /opt/grok_exporter*
+    sudo cp /tmp/remote/spire /opt/grok_exporter/patterns/spire
     sudo cp /tmp/remote/systemd/grok-exporter.service /etc/systemd/system/
     sudo systemctl enable grok-exporter.service
 fi

--- a/drew/remote/spire
+++ b/drew/remote/spire
@@ -1,0 +1,2 @@
+SPIRE_SERVER_CSR_REQUEST (%{SYSLOGLINE})((.)*Parsing CSR with SPIFFE ID:(.)*)
+SPIRE_SERVER_NODE_ATTESTATION (%{SYSLOGLINE})((.)*Received node attestation request(.)*)

--- a/drew/remote/systemd/grok-exporter.service
+++ b/drew/remote/systemd/grok-exporter.service
@@ -4,7 +4,7 @@ User=ubuntu
 Restart=always
 RestartSec=3
 WorkingDirectory=/opt/grok_exporter
-ExecStart=/opt/grok_exporter --config /opt/grok_exporter/grok_exporter.yml run
+ExecStart=/opt/grok_exporter/grok_exporter --config /opt/grok_exporter/grok_config.yml
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Install grok exporter as a systemctl process on spire server to expose target metrics to be consumed by prometheus.