### PR TITLE
Setting Envoy image version to tagged v1.8.0

### DIFF
--- a/spiffe-envoy-sidecar/back-end/backend-envoy.yaml
+++ b/spiffe-envoy-sidecar/back-end/backend-envoy.yaml
@@ -31,16 +31,17 @@ static_resources:
               filename: /tmp/certs/svid.pem
             private_key:
               filename: /tmp/certs/svid_key.pem
+          validation_context:
             trusted_ca:
               filename: /tmp/certs/svid_bundle.pem
+            verify_subject_alt_name:
+            - spiffe://example.org/front-end
           tls_params:
             ecdh_curves:
             - X25519:P-256:P-521:P-384
-        verify_subject_alt_name:
-        - spiffe://example.org/front-end
   clusters:
   - name: local_service
-    connect_timeout: 0.25s
+    connect_timeout: 10.0s
     type: strict_dns
     lb_policy: round_robin
     hosts:

--- a/spiffe-envoy-sidecar/back-end/server.xml
+++ b/spiffe-envoy-sidecar/back-end/server.xml
@@ -66,7 +66,7 @@
          APR (HTTP/AJP) Connector: /docs/apr.html
          Define a non-SSL/TLS HTTP/1.1 Connector on port 3000
     -->
-    <Connector port="8003" protocol="HTTP/1.1"
+    <Connector port="9001" protocol="HTTP/1.1"
                connectionTimeout="20000"
                redirectPort="8443" />
     <!-- A "Connector" using the shared thread pool-->

--- a/spiffe-envoy-sidecar/front-end/frontend-envoy.yaml
+++ b/spiffe-envoy-sidecar/front-end/frontend-envoy.yaml
@@ -26,7 +26,7 @@ static_resources:
             config: {}
   clusters:
   - name: backend_service
-    connect_timeout: 0.25s
+    connect_timeout: 10.0s
     type: strict_dns
     lb_policy: round_robin
     hosts:
@@ -40,13 +40,14 @@ static_resources:
             filename: /tmp/certs/svid.pem
           private_key:
             filename: /tmp/certs/svid_key.pem
+        validation_context:
           trusted_ca:
             filename: /tmp/certs/svid_bundle.pem
+          verify_subject_alt_name:
+          - spiffe://example.org/back-end
         tls_params:
           ecdh_curves:
           - X25519:P-256:P-521:P-384
-      verify_subject_alt_name:
-      - spiffe://example.org/back-end
 admin:
   access_log_path: "/dev/null"
   address:

--- a/spiffe-envoy-sidecar/front-end/start-tomcat.sh
+++ b/spiffe-envoy-sidecar/front-end/start-tomcat.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
-export JAVA_OPTS="$JAVA_OPTS -Dtasks.service=http://backend:8003/tasks/"
+export JAVA_OPTS="$JAVA_OPTS -Dtasks.service=http://localhost:8003/tasks/"
 /opt/tomcat/bin/catalina.sh run

--- a/spiffe-envoy-sidecar/spire-agent/Dockerfile
+++ b/spiffe-envoy-sidecar/spire-agent/Dockerfile
@@ -1,4 +1,4 @@
-FROM envoyproxy/envoy:latest
+FROM gcr.io/spiffe-example/envoy:v1.8.0
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends ca-certificates curl tar gzip default-jre python libltdl7
@@ -14,7 +14,7 @@ RUN mv spire-${SPIRE_VERSION} ${SPIRE_DIR}
 
 # Install Tomcat
 ARG TOMCAT_VERSION=8.5.34
-ARG TOMCAT_RELEASE="http://apache.dattatec.com/tomcat/tomcat-8/v${TOMCAT_VERSION}/bin/apache-tomcat-${TOMCAT_VERSION}.tar.gz"
+ARG TOMCAT_RELEASE="https://storage.googleapis.com/spiffe-example/apache-tomcat-${TOMCAT_VERSION}.tar.gz"
 ARG TOMCAT_DIR=/opt/tomcat
 RUN curl --silent --location ${TOMCAT_RELEASE} | tar -xzf -
 RUN mv apache-tomcat-${TOMCAT_VERSION} ${TOMCAT_DIR}


### PR DESCRIPTION
The Envoy container was updated to use the tagged version v1.8.0
Envoy configuration files were adapted to comply with v1.8.0
Tomcat release link was updated to point to gcloud storage
Tomcat ports configuration broken in last commit was amended.

Signed-off-by: Max Lambrecht <maxlambrecht@gmail.com>