### PR TITLE
Fix k8s demo

### DIFF
--- a/beatrice/blog/container_blog/Dockerfile
+++ b/beatrice/blog/container_blog/Dockerfile
@@ -10,9 +10,8 @@ RUN apt-get -y install \
 	python-mysqldb \
 	git
 
-WORKDIR /home/ubuntu
-
 RUN \
+  cd ${HOME} && \
   git clone https://github.com/sh4nks/flaskbb.git && \
   cd flaskbb && \
   pip install -r requirements.txt

--- a/beatrice/blog/container_ghostunnel/Dockerfile
+++ b/beatrice/blog/container_ghostunnel/Dockerfile
@@ -11,12 +11,10 @@ RUN apt-get -y install \
 	curl \
 	libltdl7
 
-WORKDIR /home/ubuntu
+COPY ghostunnel ${HOME}
+COPY start.sh ${HOME}
+RUN cd ${HOME} && curl --silent --location https://github.com/spiffe/sidecar/releases/download/0.1/sidecar_0.1_linux_amd64.tar.gz | tar xzf -
 
-COPY ghostunnel .
-COPY start.sh .
-RUN curl --silent --location https://github.com/spiffe/sidecar/releases/download/0.1/sidecar_0.1_linux_amd64.tar.gz | tar xzf -
-
-CMD ./start.sh
+CMD ./${HOME}/start.sh
 
 

--- a/beatrice/blog/container_ghostunnel/start.sh
+++ b/beatrice/blog/container_ghostunnel/start.sh
@@ -2,7 +2,7 @@
 
 cat << _EOF > sidecar_config.hcl
 agentAddress = "$AGENT_SOCKET"
-ghostunnelCmd = "/home/ubuntu/ghostunnel"
+ghostunnelCmd = "$HOME/ghostunnel"
 ghostunnelArgs = "client --listen $LISTEN --target $UPSTREAM --verify-spiffe-id spiffe://example.org/Database"
 certDir = "certs"
 _EOF

--- a/beatrice/install_ghostunnel.sh
+++ b/beatrice/install_ghostunnel.sh
@@ -9,23 +9,23 @@ GHOSTUNNEL_BRANCH=spiffe-support
 
 sudo apt-get -y install build-essential libltdl-dev git
 
-export PATH=/usr/local/go/bin:/home/ubuntu/go/bin:$PATH
+export PATH=/usr/local/go/bin:$HOME/go/bin:$PATH
 
 # ghostunnel requires golang1.9, so we fetch a tarball
 if ! which go; then
 	curl --silent $GOLANG_URL | sudo tar --directory /usr/local -xzf -
 fi
 
-rm -rf /home/ubuntu/go
-mkdir -p /home/ubuntu/go/src/github.com/spiffe
-cd /home/ubuntu/go/src/github.com/spiffe
+rm -rf $HOME/go
+mkdir -p $HOME/go/src/github.com/spiffe
+cd $HOME/go/src/github.com/spiffe
 git clone --branch $GHOSTUNNEL_BRANCH  https://github.com/spiffe/ghostunnel.git
 cd ghostunnel
 go install
 
 # send a copy to our container friend
-cp /home/ubuntu/go/bin/ghostunnel /extra_mount/blog/container_ghostunnel/
+cp $HOME/go/bin/ghostunnel /extra_mount/blog/container_ghostunnel/
 
 # abusing .bash_aliases to ammend PATH, for convenience
-echo "export PATH=/usr/local/go/bin:/home/ubuntu/go/bin:$PATH" > /home/ubuntu/.bash_aliases
+echo "export PATH=/usr/local/go/bin:$HOME/go/bin:$PATH" > $HOME/.bash_aliases
 

--- a/beatrice/install_spire.sh
+++ b/beatrice/install_spire.sh
@@ -13,7 +13,6 @@ cd /opt
 sudo ln -s spire-* spire
 sudo rm -rf /opt/spire/conf
 sudo cp -r /extra_mount/spire-conf /opt/spire/conf
-sudo chown -R ubuntu:ubuntu /opt/spire*
 
 #sudo cp /extra_mount/systemd/spire-${mode}.service /etc/systemd/system/
 #sudo systemctl daemon-reload

--- a/beatrice/install_spire.sh
+++ b/beatrice/install_spire.sh
@@ -4,7 +4,7 @@ set -x
 
 mode="$1"
 
-SPIRE_TGZ="https://github.com/spiffe/spire/releases/download/0.2/spire-0.2-linux-x86_64-glibc.tar.gz"
+SPIRE_TGZ="https://github.com/spiffe/spire/releases/download/0.7.0/spire-0.7.0-linux-x86_64-glibc.tar.gz"
 
 sudo rm -rf /opt/spire*
 curl --silent --location $SPIRE_TGZ | sudo tar --directory /opt -xzf -

--- a/beatrice/misc_config/sidecar_config.hcl
+++ b/beatrice/misc_config/sidecar_config.hcl
@@ -1,4 +1,4 @@
 agentAddress = "/tmp/agent.sock"
-ghostunnelCmd = "/home/ubuntu/go/bin/ghostunnel"
+ghostunnelCmd = "$HOME/go/bin/ghostunnel"
 ghostunnelArgs = "server --listen 0.0.0.0:33306 --target localhost:3306 --allow-uri-san spiffe://example.org/Blog"
-certDir = "/home/ubuntu"
+certDir = "$HOME"

--- a/beatrice/provision_db.sh
+++ b/beatrice/provision_db.sh
@@ -28,4 +28,4 @@ cat /extra_mount/blog/forum_db.dump | sudo mysql forum_db
 /extra_mount/install_sidecar.sh
 
 # drop user into /opt/spire dir
-echo "cd /opt/spire" >> /home/ubuntu/.bashrc
+echo "cd /opt/spire" >> $HOME/.bashrc

--- a/beatrice/provision_k8s-master.sh
+++ b/beatrice/provision_k8s-master.sh
@@ -20,4 +20,4 @@ kubectl create -f /extra_mount/blog/blog.yaml
 /extra_mount/install_spire.sh server
 
 # drop user into /opt/spire dir
-echo "cd /opt/spire" >> /home/ubuntu/.bashrc
+echo "cd /opt/spire" >> $HOME/.bashrc

--- a/beatrice/provision_k8s-node.sh
+++ b/beatrice/provision_k8s-node.sh
@@ -6,4 +6,4 @@ set -x
 /extra_mount/install_spire.sh agent
 
 # drop user into /opt/spire dir
-echo "cd /opt/spire" >> /home/ubuntu/.bashrc
+echo "cd /opt/spire" >> $HOME/.bashrc

--- a/beatrice/systemd/spire-agent.service
+++ b/beatrice/systemd/spire-agent.service
@@ -3,7 +3,7 @@ Description=spire-agent
 
 [Service]
 Type=simple
-User=ubuntu
+User=${USER}
 WorkingDirectory=/opt/spire
 ExecStart=/opt/spire/spire-agent run
 

--- a/beatrice/systemd/spire-server.service
+++ b/beatrice/systemd/spire-server.service
@@ -3,7 +3,7 @@ Description=spire-server
 
 [Service]
 Type=simple
-User=ubuntu
+User=${USER}
 WorkingDirectory=/opt/spire
 ExecStart=/opt/spire/spire-server run
 

--- a/vagrant_k8s/Vagrantfile
+++ b/vagrant_k8s/Vagrantfile
@@ -38,7 +38,7 @@ sudo apt-get install -y \
 	kubectl=#{$kubernetes_version}-00
 sudo apt-get install -y docker.io
 
-sudo usermod --append --groups docker ubuntu
+sudo usermod --append --groups docker ${USER}
 _SCRIPT
 
 $setup_master = <<_SCRIPT
@@ -51,11 +51,11 @@ sudo kubeadm init \
 	--token=nogood.choiceforasecret \
 	--apiserver-advertise-address=#{$master_ip}
 
-mkdir -p /home/ubuntu/.kube
-sudo cp /etc/kubernetes/admin.conf /home/ubuntu/.kube/config
-sudo chown -R ubuntu:ubuntu /home/ubuntu/.kube
+mkdir -p ${HOME}/.kube
+sudo cp /etc/kubernetes/admin.conf ${HOME}/.kube/config
+sudo chown -R ${USER}:${USER} ${HOME}/.kube
 
-export KUBECONFIG=/home/ubuntu/.kube/config
+export KUBECONFIG=${HOME}/.kube/config
 kubectl apply --filename=/vagrant/flannel.yaml
 kubectl apply --filename=/vagrant/registry.yaml
 


### PR DESCRIPTION
Recently trying out the example on mac after upgrading vagrant, got following errors:
```
db: + mkdir -p /home/ubuntu/go/src/github.com/spiffe
db: mkdir:
db: cannot create directory '/home/ubuntu/go'
db: : Permission denied
```

The reason is vagrant is using user `vagrant` instead of `ubuntu`, so it hit permission issue. Now use environment variable to determine the home directory and current user to get around the issue.